### PR TITLE
Email templates via App extensions

### DIFF
--- a/pages/cart/cart.js
+++ b/pages/cart/cart.js
@@ -52,7 +52,7 @@ export function getCartLocation() {
     const cartkey = getLastCartKey();
     const orderFormData = JSON.parse(localStorage.getItem('orderFormData'));
     if (cartkey === 'merch') {
-      currentLocation = orderFormData && orderFormData.isPickupOrder ? 'shipping' : 'pickup';
+      currentLocation = orderFormData && orderFormData.isPickupOrder ? 'pickup' : 'shipping';
     } else {
       currentLocation = cartkey;
     }


### PR DESCRIPTION
- Added logic to send order confirmation emails
- set up new google sheet to allow authors to add and edit emails that are sent to customers.
- Set up app scripts on that sheet to dispatch emails

Test URLs:
- Before: https://main--site--normal-icecream.aem.live/
- After: https://feat-email-templates--site--normal-icecream.aem.live/
